### PR TITLE
[BUGFIX] Add fallbacks for display name

### DIFF
--- a/Scripts/GitScript.php
+++ b/Scripts/GitScript.php
@@ -37,7 +37,7 @@ class GitScript
 
         $pushUrl = 'ssh://' . $userData['username'] . '@review.typo3.org:29418/Packages/TYPO3.CMS.git';
         self::setGitConfigValue($event, 'remote.origin.pushurl', $pushUrl);
-        self::setGitConfigValue($event, 'user.name', $userData['display_name']);
+        self::setGitConfigValue($event, 'user.name', $userData['display_name'] ?? $userData['name'] ?? $userData['username']);
         self::setGitConfigValue($event, 'user.email', $userData['email']);
     }
 


### PR DESCRIPTION
In my case, $userData['display_name'] is not set, instead the API returns my name in the ['name'] field. To make absolutely sure a value is set, the last fallback is to the given username.