### PR TITLE
[TASK] Update ddev config

### DIFF
--- a/Scripts/InitializeScript.php
+++ b/Scripts/InitializeScript.php
@@ -131,13 +131,14 @@ router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: "10.3"
+mariadb_version: "10.5"
 mysql_version: ""
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: ""
-web_environment: []
+web_environment: 
+ - TYPO3_CONTEXT=Development
 EOF;
 
                     $filesystem = new Filesystem();


### PR DESCRIPTION
- Add TYPO3_CONTEXT=Development by default (and as an example of how to set env vars with ddev)
- Use MariaDB 10.5
Both changes are "nice to have" ;) but feel free to decline them, if you don't want them :)