### PR TITLE
Remove minimum stability dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,15 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate --no-check-all --no-check-lock
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+# Disable cache for now as it causes more issues than it solves
+#      - name: Cache Composer packages
+#        id: composer-cache
+#        uses: actions/cache@v2
+#        with:
+#          path: vendor
+#          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+#          restore-keys: |
+#            ${{ runner.os }}-php-
 
       - name: Install dependencies
         # Do a clone here to make sure the repository exists on install

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
             "url": "packages/*"
         }
     },
-    "minimum-stability": "dev",
     "autoload-dev": {
         "psr-4": {
             "Ochorocho\\Tdk\\Scripts\\": "Scripts/"


### PR DESCRIPTION
Currently the typo3 console is not working, as 5.4.x-dev is loaded instead of 5.4.11