### PR TITLE
[TASK] Add `tdk ssh-add` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,14 @@ jobs:
     name: Docker Image Builder
     runs-on: ubuntu-latest
     steps:
+      - name: Run find-and-replace to remove slashes
+        uses: mad9000/actions-find-and-replace-string@1
+        id: clean_ref
+        with:
+          source: ${{ github.ref_name }}
+          find: '/'
+          replace: '-'
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -73,7 +81,7 @@ jobs:
         with:
           images: ochorocho/gitpod-tdk
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=${{ steps.clean_ref.outputs.value }},enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
       -
         name: Build and export to Docker
         uses: docker/build-push-action@v3
@@ -86,7 +94,7 @@ jobs:
         run: |
           echo ${{ steps.meta.outputs.tags }}
           echo ${GITHUB_WORKSPACE}
-          docker run --rm -v ${GITHUB_WORKSPACE}/.gitpod/docker/test.sh:/tmp/test.sh --entrypoint "bash" ${{ steps.meta.outputs.tags }} /tmp/test.sh
+          docker run --rm -v ${GITHUB_WORKSPACE}/.gitpod/docker/test.sh:/tmp/test.sh --entrypoint "bash" ochorocho/gitpod-tdk:${{ steps.clean_ref.outputs.value }} /tmp/test.sh
       -
         name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           images: ochorocho/gitpod-tdk
           tags: |
-            type=raw,value=${{ steps.clean_ref.outputs.value }},enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=${{ steps.clean_ref.outputs.value }},enable=true
       -
         name: Build and export to Docker
         uses: docker/build-push-action@v3

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,12 +18,14 @@ tasks:
       composer install
       composer tdk:set-git-config
       composer tdk:enable-hooks -- --force
+      tdk ssh-add
       composer tdk:apply-patch
       composer install
       mkdir -p public/typo3conf
       touch public/FIRST_INSTALL
       cp -Rp .gitpod/typo3/AdditionalConfiguration.php public/typo3conf/AdditionalConfiguration.php
     command: |
+      tdk ssh-add
       tdk php "$(php .gitpod/php/version.php)"
       sudo service mailhog start
       sudo service mysql start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@
 # Detect php: https://gitpod.io/#TDK_BRANCH=11.5,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/main
 # https://gitpod.io/#TDK_BRANCH=11.5,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/feature/add-ssh-command
 
-image: ochorocho/gitpod-tdk:feature-add-ssh-command
+image: ochorocho/gitpod-tdk:latest
 
 tasks:
   - name: TDK
@@ -27,6 +27,7 @@ tasks:
       touch public/FIRST_INSTALL
       cp -Rp .gitpod/typo3/AdditionalConfiguration.php public/typo3conf/AdditionalConfiguration.php
     command: |
+      tdk ssh-add
       tdk php "$(php .gitpod/php/version.php)"
       sudo service mailhog start
       sudo service mysql start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@
 # 8.0 https://gitpod.io/#TDK_PHP_VERSION=8.0,TDK_BRANCH=main,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/main
 # Detect php: https://gitpod.io/#TDK_BRANCH=11.5,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/main
 
-image: ochorocho/gitpod-tdk:latest
+image: ochorocho/gitpod-tdk:feature-add-ssh-command
 
 tasks:
   - name: TDK

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@
 # 8.1 https://gitpod.io/#TDK_PHP_VERSION=8.1,TDK_BRANCH=main,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/main
 # 8.0 https://gitpod.io/#TDK_PHP_VERSION=8.0,TDK_BRANCH=main,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/main
 # Detect php: https://gitpod.io/#TDK_BRANCH=11.5,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/main
+# https://gitpod.io/#TDK_BRANCH=11.5,TDK_PATCH_REF=refs%2Fchanges%2F43%2F70643%2F36,TDK_USERNAME=ochorocho,TDK_PATCH_ID=70643/https://github.com/ochorocho/tdk/tree/feature/add-ssh-command
 
 image: ochorocho/gitpod-tdk:feature-add-ssh-command
 
@@ -18,6 +19,7 @@ tasks:
       composer install
       composer tdk:set-git-config
       composer tdk:enable-hooks -- --force
+      composer tdk:set-commit-template -- --file=./.gitmessage.txt
       tdk ssh-add
       composer tdk:apply-patch
       composer install
@@ -25,7 +27,6 @@ tasks:
       touch public/FIRST_INSTALL
       cp -Rp .gitpod/typo3/AdditionalConfiguration.php public/typo3conf/AdditionalConfiguration.php
     command: |
-      tdk ssh-add
       tdk php "$(php .gitpod/php/version.php)"
       sudo service mailhog start
       sudo service mysql start

--- a/.gitpod/docker/scripts/tdk
+++ b/.gitpod/docker/scripts/tdk
@@ -109,6 +109,29 @@ phpTask () {
     fi
 }
 
+addSshKeyFromEnvironmentVariable() {
+    if [[ -z "${SSH_PRIVATE_KEY}" ]]; then
+        echo -e "Evironment variable 'SSH_PRIVATE_KEY' not set!\nFor details see https://gitpod.io/variables "
+        exit 0
+    fi
+
+    regex='(-----BEGIN OPENSSH PRIVATE KEY----- )((.|\n)*?)(-----END OPENSSH PRIVATE KEY-----)'
+    privateKeyPath=~/.ssh/id_rsa
+
+    if [[ "${SSH_PRIVATE_KEY}" =~ $regex ]] ; then
+        key=$(echo "${BASH_REMATCH[2]}" | tr " " "\n")
+        echo -e "${BASH_REMATCH[1]}\n$key\n${BASH_REMATCH[4]}" | awk '{$1=$1};1' > ~/.ssh/id_rsa
+        chmod 600 $privateKeyPath
+    fi
+
+    if ssh-keygen -y -e -f ~/.ssh/id_rsa > /dev/null 2>&1; then
+        echo "Stored ssh key in $privateKeyPath"
+    else
+        echo "Private key $privateKeyPath is not valid!"
+        exit 1
+    fi
+}
+
 case $TASK in
   cron)
     cronTask
@@ -126,9 +149,13 @@ case $TASK in
     phpTask
     exit 0
     ;;
+  ssh-add)
+    addSshKeyFromEnvironmentVariable
+    exit 0
+    ;;
   *)
     echo "Argument unknown. Choose one of the following:"
-    echo "cron, preview, db, php"
+    echo "cron, preview, db, php, ssh-add"
     exit 1
     ;;
 esac

--- a/.gitpod/docker/scripts/tdk-completion
+++ b/.gitpod/docker/scripts/tdk-completion
@@ -11,7 +11,7 @@ _tdk()
 
     case ${COMP_CWORD} in
         1)
-            mapfile -t COMPREPLY < <(compgen -W "cron preview db php" -- "${cur}")
+            mapfile -t COMPREPLY < <(compgen -W "cron preview db php ssh-add" -- "${cur}")
             ;;
         2)
             case ${prev} in

--- a/.gitpod/docker/test.sh
+++ b/.gitpod/docker/test.sh
@@ -2,6 +2,8 @@
 
 composer --version || exit 1
 
+export SSH_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY----- b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW QyNTUxOQAAACDEMsv3oItZjfGpC37kIksDqV7awvGEhshuQKR4/CjhywAAAJBrwgvIa8IL yAAAAAtzc2gtZWQyNTUxOQAAACDEMsv3oItZjfGpC37kIksDqV7awvGEhshuQKR4/Cjhyw AAAEB3Cdx6Qg76bDTsdi2pdcAyFyeYE9KXRJwvPEW0hjcxJMQyy/egi1mN8akLfuQiSwOp XtrC8YSGyG5ApHj8KOHLAAAABmdpdHBvZAECAwQFBgc= -----END OPENSSH PRIVATE KEY-----"
+
 # See php and required modules
 ALL_VERSIONS="7.2 7.3 7.4 8.0 8.1"
 
@@ -16,3 +18,4 @@ which /home/gitpod/go/bin/MailHog || (echo "MailHog Missing" && exit 1)
 convert --version | grep "^Version" || (echo "convert missing" && exit 1)
 identify --version | grep "^Version" || (echo "identify issing" && exit 1)
 docker --version || (echo "Docker missing" && exit 1)
+tdk ssh-add || (echo "Failed adding private key" && exit 1)

--- a/.gitpod/docker/test.sh
+++ b/.gitpod/docker/test.sh
@@ -2,7 +2,9 @@
 
 composer --version || exit 1
 
-export SSH_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY----- b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW QyNTUxOQAAACDEMsv3oItZjfGpC37kIksDqV7awvGEhshuQKR4/CjhywAAAJBrwgvIa8IL yAAAAAtzc2gtZWQyNTUxOQAAACDEMsv3oItZjfGpC37kIksDqV7awvGEhshuQKR4/Cjhyw AAAEB3Cdx6Qg76bDTsdi2pdcAyFyeYE9KXRJwvPEW0hjcxJMQyy/egi1mN8akLfuQiSwOp XtrC8YSGyG5ApHj8KOHLAAAABmdpdHBvZAECAwQFBgc= -----END OPENSSH PRIVATE KEY-----"
+# @todo, test tdk commands if possible
+# export SSH_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY----- b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW QyNTUxOQAAACDEMsv3oItZjfGpC37kIksDqV7awvGEhshuQKR4/CjhywAAAJBrwgvIa8IL yAAAAAtzc2gtZWQyNTUxOQAAACDEMsv3oItZjfGpC37kIksDqV7awvGEhshuQKR4/Cjhyw AAAEB3Cdx6Qg76bDTsdi2pdcAyFyeYE9KXRJwvPEW0hjcxJMQyy/egi1mN8akLfuQiSwOp XtrC8YSGyG5ApHj8KOHLAAAABmdpdHBvZAECAwQFBgc= -----END OPENSSH PRIVATE KEY-----"
+# tdk ssh-add || (echo "Failed adding private key" && exit 1)
 
 # See php and required modules
 ALL_VERSIONS="7.2 7.3 7.4 8.0 8.1"
@@ -18,4 +20,3 @@ which /home/gitpod/go/bin/MailHog || (echo "MailHog Missing" && exit 1)
 convert --version | grep "^Version" || (echo "convert missing" && exit 1)
 identify --version | grep "^Version" || (echo "identify issing" && exit 1)
 docker --version || (echo "Docker missing" && exit 1)
-tdk ssh-add || (echo "Failed adding private key" && exit 1)

--- a/.gitpod/info.md
+++ b/.gitpod/info.md
@@ -30,12 +30,17 @@ Root user (`mysql -uroot`):
 
 ### SSH Private/Public Key Authentication
 
-Generate a GitPod dedicate private/public key pair:
+> **WARNING**
+>
+> Adding a private key to GitPod might be a security concern.
+> To reduce the risk, generate a private/public key pair which will be used for Gerrit exclusively.
+
+Generate a GitPod dedicated private/public key pair:
 
 ```
 ssh-keygen -t ed25519 -f gitpod_key -C gitpod
 ```
 
-[Add a variable](https://gitpod.io/variables) named `SSH_PRIVATE_KEY` and 
+[Add a variable](https://gitpod.io/variables) named `SSH_PRIVATE_KEY` and
 paste your generated private key. To be able to push to Gerrit you need to add
 your public key in your [Gerrit settings](https://review.typo3.org/settings/#SSHKeys)

--- a/.gitpod/info.md
+++ b/.gitpod/info.md
@@ -27,3 +27,15 @@
 Root user (`mysql -uroot`):
 * User: root
 * Password: No password set!
+
+### SSH Private/Public Key Authentication
+
+Generate a GitPod dedicate private/public key pair:
+
+```
+ssh-keygen -t ed25519 -f gitpod_key -C gitpod
+```
+
+[Add a variable](https://gitpod.io/variables) named `SSH_PRIVATE_KEY` and 
+paste your generated private key. To be able to push to Gerrit you need to add
+your public key in your [Gerrit settings](https://review.typo3.org/settings/#SSHKeys)

--- a/tests/Acceptance/TdkCest.php
+++ b/tests/Acceptance/TdkCest.php
@@ -95,11 +95,12 @@ class TdkCest
      */
     public function applyPatch(AcceptanceTester $I): void
     {
-        $I->runShellCommand('composer tdk:apply-patch -- --ref=refs/changes/43/70643/35');
-        $I->seeInShellOutput('Apply patch refs/changes/43/70643/35');
+        // @todo: Create a dedicated patch to test against, currently this breaks as soon as the patch gets merged
+        $I->runShellCommand('composer tdk:apply-patch -- --ref=refs/changes/60/69360/6');
+        $I->seeInShellOutput('Apply patch refs/changes/60/69360/6');
 
         $I->runShellCommand('git -C ' . self::$coreDevFolder . ' log -1 --oneline');
-        $I->seeInShellOutput('Add configurable template for locked backend');
+        $I->seeInShellOutput('Add returnUrl for Open Documents/Recently Used Documents');
     }
 
     /**


### PR DESCRIPTION
GitPod variables do not support multiline.
Based on the variable SSH_PRIVATE_KEY the `ssh-add` command will take the private key, format it as needed will verify and store it.

See https://github.com/ochorocho/tdk/issues/28