### PR TITLE
Allow "minimum-stability: RC"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,5 +103,6 @@
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true
         }
-    }
+    },
+    "minimum-stability": "RC"
 }


### PR DESCRIPTION
The current TYPO3 core development requires "doctrine/dbal 4.0.0-RC2@rc" which cannot be installed without explicitly allowing "RC"

Here is the current error message, I ran into.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - typo3/cms-core[dev-main, 13.1.x-dev] require doctrine/dbal 4.0.0-RC2@rc -> found doctrine/dbal[4.0.0-RC2] but it does not match your minimum-stability.
    - typo3/cms-core 13.1.x-dev is an alias of typo3/cms-core dev-main and thus requires it to be installed too.
    - Root composer.json requires typo3/cms-core @dev -> satisfiable by typo3/cms-core[dev-main, 13.1.x-dev (alias of dev-main)].
```

![Bildschirmfoto vom 2024-01-31 20-00-48](https://github.com/ochorocho/tdk/assets/16088567/dded8486-e1be-419e-9c51-3069eb59f1be)
